### PR TITLE
Fix logger undefined error in gcp sku downloader

### DIFF
--- a/gcp-sku-download.log
+++ b/gcp-sku-download.log
@@ -1,0 +1,3 @@
+2025-08-07 06:47:37,984 - INFO - Fetching GCP access token from gcloud CLI...
+2025-08-07 06:47:37,985 - ERROR - Unexpected error getting access token: [Errno 2] No such file or directory: 'gcloud'
+2025-08-07 06:47:37,985 - ERROR - Download failed: [Errno 2] No such file or directory: 'gcloud'


### PR DESCRIPTION
Fixes `NameError: name 'logger' is not defined` by ensuring the logger is initialized before use and protecting all logger calls.

---
<a href="https://cursor.com/background-agent?bcId=bc-13d29ef1-9bc8-4c42-87a2-86cc56c54c74">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-13d29ef1-9bc8-4c42-87a2-86cc56c54c74">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

